### PR TITLE
Make the keyboard stick to the bottom of the display with a padding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,12 @@ vboard saves its settings to ~/.config/vboard/settings.conf. This configuration 
 - Background color
 - Opacity level
 - Text color
+- Bottom padding (distance in pixels from the bottom of the screen)
+- Stick-to-bottom (whether the keyboard snaps to the bottom center of the screen)
+
 You can manually edit this file or use the built-in interface controls to customize the appearance.
+
+*Known issue*: If `bottom_padding` is set to `0`, a few rows of the keyboard may be cropped by the display area; the cause is still under investigation.
 
 ### Customizing Keyboard Layout
 The keyboard layout is defined in the rows list in the source code. To modify the layout:


### PR DESCRIPTION
Thank you for the lightweight keyboard. It is so helpful, I tried other virtual keyboards in my environment and they are too smart and became annoying. This is exactly the simple solution I am looking for.

The change makes the keyboard stick to the bottom of the display with a padding. So it is easier to reach in tablet mode.

The padding size can be tuned in the config file:

```
bottom_padding = 150
```

Known issues: 
* There is not an option to disable this behavior.
* When setting the padding to 0, the last 2 rows of the keyboard are cropped out side the display area. I haven't figured out why. It may have something to do with the display scaling.
