### PR TITLE
Remember the last position of the window in landscape and portrait mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ vboard saves its settings to ~/.config/vboard/settings.conf. This configuration 
 - Background color
 - Opacity level
 - Text color
+- Last window position and size (separately for landscape and portrait orientations)
+
 You can manually edit this file or use the built-in interface controls to customize the appearance.
 
 ### Customizing Keyboard Layout


### PR DESCRIPTION
Remember the last position of the window in landscape and portrait mode.
When the user moves the window, it remembers the latest size and position. The size and position is saved separately in landscape and portrait mode.

Known issues:
1. It only works on the primary display.
2. In GTK, a configure event is fired right before the on screen change, and it set the window to a weird position. So I used a work around by delaying the event by 100ms. Here is a magic number and not ideal.
